### PR TITLE
Port to 1.21.11 & bugfixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,20 +17,31 @@ repositories {
     maven("https://repo.codemc.org/repository/maven-public/")
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.codehaus.plexus:plexus-utils:4.0.3")
+        force("org.apache.commons:commons-lang3:3.18.0")
+    }
+}
+
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.force("org.codehaus.plexus:plexus-utils:4.0.3")
+        resolutionStrategy.force("org.apache.commons:commons-lang3:3.18.0")
+    }
+}
+
 dependencies {
     compileOnly("com.discordsrv:discordsrv:1.30.1")
-    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     implementation("commons-io:commons-io:2.20.0")
-    implementation("dev.jorel:commandapi-bukkit-shade:10.1.2")
+    compileOnly("dev.jorel:commandapi-bukkit-core:11.2.0")
 }
 
 tasks.withType<ShadowJar> {
     dependencies {
-        include(dependency("dev.jorel:commandapi-bukkit-shade:10.1.2"))
         include(dependency("org.bstats:bstats-bukkit:3.0.3"))
     }
-
-    relocate("dev.jorel.commandapi", "com.buape.kiaimc.commandapi")
 }
 
 tasks.named<ShadowJar>("shadowJar") {
@@ -42,7 +53,7 @@ tasks.build {
 }
 
 group = "com.buape"
-version = "3.0.0"
+version = "3.1.0"
 description = "KiaiMC - Integrating Kiai's extensive leveling system with Minecraft servers"
 
 java {

--- a/src/main/java/com/buape/kiaimc/KiaiMC.java
+++ b/src/main/java/com/buape/kiaimc/KiaiMC.java
@@ -14,9 +14,6 @@ import com.buape.kiaimc.modules.ChatModule;
 import com.buape.kiaimc.modules.CommandModule;
 import com.buape.kiaimc.modules.PlayTimeModule;
 
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIBukkitConfig;
-import dev.jorel.commandapi.CommandAPILogger;
 import github.scarsz.discordsrv.dependencies.bstats.bukkit.Metrics;
 
 public final class KiaiMC extends JavaPlugin {
@@ -44,7 +41,7 @@ public final class KiaiMC extends JavaPlugin {
             String baseUrl = getConfig().getString("base-url");
 
             if (baseUrl == null || baseUrl.isBlank()) {
-                baseUrl = "https://api.kiai.app/v2";
+                baseUrl = "https://www.kiai.app/api/v2";
             }
 
             this.api = new Kiai(token, this.logger, this.getConfig().getBoolean("debug"), baseUrl);
@@ -59,19 +56,8 @@ public final class KiaiMC extends JavaPlugin {
                 new PlayTimeModule(this);
             }
 
-            CommandAPI.onEnable();
             new CommandModule(this).registerAllCommands();
         }
-    }
-
-    @Override
-    public void onLoad() {
-        CommandAPI.setLogger(CommandAPILogger.fromJavaLogger(getLogger()));
-        CommandAPI.onLoad(
-                new CommandAPIBukkitConfig(this)
-                        .verboseOutput(this.getConfig().getBoolean("debug"))
-                        .usePluginNamespace()
-                        .dispatcherFile(new File(getDataFolder(), "command_registration.json")));
     }
 
     @Override

--- a/src/main/java/com/buape/kiaimc/modules/CommandModule.java
+++ b/src/main/java/com/buape/kiaimc/modules/CommandModule.java
@@ -1,12 +1,12 @@
 package com.buape.kiaimc.modules;
 
+import dev.jorel.commandapi.arguments.EntitySelectorArgument;
 import org.bukkit.entity.Player;
 
 import com.buape.kiaimc.KiaiMC;
 
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
-import dev.jorel.commandapi.arguments.PlayerArgument;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import github.scarsz.discordsrv.DiscordSRV;
 import net.md_5.bungee.api.ChatColor;
@@ -20,7 +20,7 @@ public class CommandModule {
 
 	public void registerAllCommands() {
 		new CommandAPICommand("addxp")
-				.withArguments(new PlayerArgument("player"))
+				.withArguments(new EntitySelectorArgument.OnePlayer("player"))
 				.withArguments(new IntegerArgument("amount"))
 				.withHelp("Add XP to a player", "Add XP in Kiai to player through Minecraft")
 				.withUsage("/addxp <player> <amount>")
@@ -33,8 +33,7 @@ public class CommandModule {
 						throw CommandAPI.failWithString(
 								String.format("%s is not linked to a Discord account!", player.getName()));
 					}
-					plugin.api.addXp(DiscordSRV.getPlugin().getMainGuild().getId(), player.getUniqueId().toString(),
-							amount);
+                    plugin.api.addXp(DiscordSRV.getPlugin().getMainGuild().getId(), discordId, amount);
 					if (sender instanceof Player) {
 						sender.sendMessage(
 								ChatColor.GREEN + "You have given " + player.getName() + " " + amount + " XP");
@@ -42,7 +41,7 @@ public class CommandModule {
 				}).register();
 
 		new CommandAPICommand("removexp")
-				.withArguments(new PlayerArgument("player"))
+				.withArguments(new EntitySelectorArgument.OnePlayer("player"))
 				.withArguments(new IntegerArgument("amount"))
 				.withHelp("Remove XP from a player", "Remove XP in Kiai from player through Minecraft")
 				.withUsage("/removexp <player> <amount>")
@@ -55,10 +54,9 @@ public class CommandModule {
 						throw CommandAPI.failWithString(
 								String.format("%s is not linked to a Discord account!", player.getName()));
 					}
-					plugin.api.removeXp(DiscordSRV.getPlugin().getMainGuild().getId(), player.getUniqueId()
-							.toString(), amount);
+                    plugin.api.removeXp(DiscordSRV.getPlugin().getMainGuild().getId(), discordId, amount);
 					if (sender instanceof Player) {
-						sender.sendMessage(net.md_5.bungee.api.ChatColor.GREEN + "You have taken " + amount
+						sender.sendMessage(ChatColor.GREEN + "You have taken " + amount
 								+ " XP from " + player.getName());
 					}
 				}).register();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: KiaiMC
 version: ${version}
 main: com.buape.kiaimc.KiaiMC
-api-version: 1.21.8
+api-version: 1.21.11
 author: thewilloftheshadow
-depend: [DiscordSRV]
+depend: [DiscordSRV, CommandAPI]
 load: POSTWORLD
 website: "https://github.com/buape/KiaiMC"
 description: Synchronize your in-game messages and playtime with Kiai's XP


### PR DESCRIPTION
- Updated API requests to send Discord IDs instead of Minecraft UUIDs.
- Moved CommandAPI from shadowJar to a standalone dependency to prevent bytecode corruption on Paper 1.20.5+.
- Ported codebase to Minecraft 1.21.11 and CommandAPI v11.2.0.
- Forced updates for plexus-utils (4.0.3) and commons-lang3 (3.18.0) to patch critical vulnerabilities.
- Updated default base-url to the new kiai.app baseUrl to avoid 308 errors.